### PR TITLE
style: small spelling mistake

### DIFF
--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -13,5 +13,5 @@ services:
       - /run/bird/bird.ctl:/var/run/bird.ctl # if not using bird can remove
     environment:
       - CORS_ORIGIN=https://lg.example.com # set to your domain
-      - BGP_ENABLED=true # allow bgp queryies
+      - BGP_ENABLED=true # allow bgp queries
       - PINGTRACE_ENABLED=false # allow ping/trace/mtr


### PR DESCRIPTION
The plural of "query" is spelled "queries", where the "y" changes to "ies".