### PR TITLE
Fixed NGINX /files/ path

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ server {
     server_name lg-api.nyc.example.com;
 
     location /files/ {
-        root /var/www/lg/files;
+        root /var/www/lg/;
     }
     location / {
         include proxy_params;


### PR DESCRIPTION
Basically, NGINX will try to access /var/www/lg/files/files if it's set as that since the `root` directive already accounts for the /files/ in the path.